### PR TITLE
Fix option serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ riderModule.iml
 /_ReSharper.Caches/
 .idea/
 .ionide/
+.vs/
+*.*proj.user

--- a/FSharpConverters.fs
+++ b/FSharpConverters.fs
@@ -1,0 +1,93 @@
+﻿// https://gist.github.com/mbuhot/c224f15e0266adf5ba8ca4e882f88a75
+
+namespace System.Text.Json
+
+open System
+open System.Collections.Generic
+open System.Text.Json.Serialization
+
+// Converts Option<T> to/from JSON by projecting to null or T
+type OptionValueConverter<'T>() =
+    inherit JsonConverter<'T option>()
+
+    override this.Read (reader: byref<Utf8JsonReader>, _typ: Type, options: JsonSerializerOptions) =
+        match reader.TokenType with
+        | JsonTokenType.Null -> None
+        | _ -> Some <| JsonSerializer.Deserialize<'T>(&reader, options)
+
+    override this.Write (writer: Utf8JsonWriter, value: 'T option, options: JsonSerializerOptions) =
+        match value with
+        | None -> writer.WriteNullValue ()
+        | Some value -> JsonSerializer.Serialize(writer, value, options)
+
+// Instantiates the correct OptionValueConverter<T>
+type OptionConverter() =
+    inherit JsonConverterFactory()
+        override this.CanConvert(t: Type) : bool =
+            t.IsGenericType &&
+            t.GetGenericTypeDefinition() = typedefof<Option<_>>
+
+        override this.CreateConverter(typeToConvert: Type,
+                                      _options: JsonSerializerOptions) : JsonConverter =
+            let typ = typeToConvert.GetGenericArguments() |> Array.head
+            let converterType = typedefof<OptionValueConverter<_>>.MakeGenericType(typ)
+            Activator.CreateInstance(converterType) :?> JsonConverter
+
+// Converts Map<K,V> to/from JSON by projecting to Dictionary<K,V>
+type MapValueConverter<'K, 'V when 'K : comparison>() =
+    inherit JsonConverter<Map<'K, 'V>>()
+
+    override this.Read (reader: byref<Utf8JsonReader>, _typ: Type, options: JsonSerializerOptions) =
+        JsonSerializer.Deserialize<System.Collections.Generic.Dictionary<'K, 'V>>(&reader, options)
+        |> Seq.map (|KeyValue|)
+        |> Map.ofSeq
+
+    override this.Write (writer: Utf8JsonWriter, value: Map<'K, 'V>, options: JsonSerializerOptions) =
+        let dictionary = Dictionary<'K, 'V>()
+        value |> Map.iter (fun k v -> dictionary.Add(k, v))
+        JsonSerializer.Serialize(writer, dictionary, options)
+
+// Instantiates the correct MapValueConverter<T>
+type MapConverter() =
+    inherit JsonConverterFactory()
+        override this.CanConvert(t: Type) : bool =
+            t.IsGenericType &&
+            List.contains (t.GetGenericTypeDefinition()) [typedefof<Map<_, _>>; typedefof<IDictionary<_,_>>]
+
+        override this.CreateConverter(typeToConvert: Type,
+                                      _options: JsonSerializerOptions) : JsonConverter =
+            let typArgs = typeToConvert.GetGenericArguments()
+            let converterType = typedefof<MapValueConverter<_,_>>.MakeGenericType(typArgs)
+            Activator.CreateInstance(converterType) :?> JsonConverter
+
+// Converts List<T> to/from JSON by projecting to IEnumerable<T>
+type ListValueConverter<'T>() =
+    inherit JsonConverter<'T list>()
+
+    override this.Read (reader: byref<Utf8JsonReader>, _typ: Type, options: JsonSerializerOptions) =
+        JsonSerializer.Deserialize<'T seq>(&reader, options)
+        |> List.ofSeq
+
+    override this.Write (writer: Utf8JsonWriter, value: 'T list, options: JsonSerializerOptions) =
+        JsonSerializer.Serialize(writer, (List.toSeq value), options)
+
+// Instantiates the correct ListValueConverter<T>
+type ListConverter() =
+    inherit JsonConverterFactory()
+        override this.CanConvert(t: Type) : bool =
+            t.IsGenericType &&
+            List.contains (t.GetGenericTypeDefinition()) [typedefof<list<_>>; typedefof<IReadOnlyCollection<_>>]
+
+        override this.CreateConverter(typeToConvert: Type,
+                                      _options: JsonSerializerOptions) : JsonConverter =
+            let typArgs = typeToConvert.GetGenericArguments()
+            let converterType = typedefof<ListValueConverter<_>>.MakeGenericType(typArgs)
+            Activator.CreateInstance(converterType) :?> JsonConverter
+
+module FSharpConverters =
+    let Options =
+        let opt = JsonSerializerOptions()
+        opt.Converters.Add(new OptionConverter()) |> ignore
+        opt.Converters.Add(new MapConverter()) |> ignore
+        opt.Converters.Add(new ListConverter()) |> ignore
+        opt

--- a/Tests/SourceMapGenerator.fs
+++ b/Tests/SourceMapGenerator.fs
@@ -27,10 +27,15 @@ module SourceMapGeneratorTests =
         Assert.True map.sourceRoot.IsNone
     
     [<Fact>]
-    let ``test  JSON serialization`` () =
+    let ``test JSON serialization 1`` () =
         let map = SourceMapGenerator(file="foo.js",sourceRoot=".")
         let s = map.ToString()
         Assert.NotNull s
+
+    [<Fact>]
+    let ``test JSON serialization 2`` () =
+        let s = testMap.Serialize()
+        Assert.Equal("""{"version":3,"sources":["one.js","two.js"],"names":["bar","baz","n"],"mappings":"CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA","file":"min.js","sourcesContent":null,"sourceRoot":"/the/root"}""", s)
         
     [<Fact>]
     let ``test adding mappings (case 1)`` () =

--- a/Tests/Util.fs
+++ b/Tests/Util.fs
@@ -10,7 +10,7 @@ type TestUtils =
     Assert.Equal (s1.ToString(),s2.ToString())
   
   static member assertEqualSourceMaps(s1:SourceMapGenerator,s2:SourceGeneratorJSON) =
-    Assert.Equal (s1.ToString(),JsonSerializer.Serialize(s2))
+    Assert.Equal (s1.ToString(),s2.Serialize())
     
 module UtilTests =
     [<Fact>]

--- a/source-map-sharp.fsproj
+++ b/source-map-sharp.fsproj
@@ -9,13 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="FSharpConverters.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Compile Include="src/Util.fs" />
         <Compile Include="src/ArraySet.fs" />
         <Compile Include="src/MappingList.fs" />
         <Compile Include="src/Base64VLQ.fs" />
         <Compile Include="src/SourceMapGenerator.fs" />
         <Compile Include="src/SourceNode.fs" />
-        <Compile Include="src/SourceMapConsumer.fs"/>
+        <Compile Include="src/SourceMapConsumer.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SourceMapGenerator.fs
+++ b/src/SourceMapGenerator.fs
@@ -123,7 +123,7 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
 
 #if !FABLE_COMPILER
     // Render the source map being generated to a string.
-    override this.ToString() = System.Text.Json.JsonSerializer.Serialize(this.toJSON())
+    override this.ToString() = this.toJSON().Serialize()
 #endif
 
     // Serialize the accumulated mappings in to the stream of base 64 VLQs

--- a/src/Util.fs
+++ b/src/Util.fs
@@ -21,6 +21,9 @@ module Util =
         /// Render the source map being generated to a string.
         member this.Serialize() =
             System.Text.Json.JsonSerializer.Serialize(this, System.Text.Json.FSharpConverters.Options)
+        /// Write the source map being generated to a stream.
+        member this.SerializeAsync stream =
+            System.Text.Json.JsonSerializer.SerializeAsync(stream, this, System.Text.Json.FSharpConverters.Options)
 
     type RawSection = {
         offset: MappingIndex

--- a/src/Util.fs
+++ b/src/Util.fs
@@ -10,15 +10,17 @@ module Util =
         Name: string option
     }
 
-    type SourceGeneratorJSON = {
-        version: int
-        sources: seq<string>
-        names: seq<string>
-        mappings: string
-        file: string option
-        sourcesContent: seq<string option> option
-        sourceRoot: string option
-    }
+    type SourceGeneratorJSON =
+        {   version: int
+            sources: seq<string>
+            names: seq<string>
+            mappings: string
+            file: string option
+            sourcesContent: seq<string option> option
+            sourceRoot: string option }
+        /// Render the source map being generated to a string.
+        member this.Serialize() =
+            System.Text.Json.JsonSerializer.Serialize(this, System.Text.Json.FSharpConverters.Options)
 
     type RawSection = {
         offset: MappingIndex


### PR DESCRIPTION
`SourceGeneratorJSON` records are currently serialized without taking care of F# types, yielding an incorrect result.

From the tests :
```fsharp
let testMap: SourceGeneratorJSON = {
     version=3
     file="min.js"|>Some
     sources= seq {"one.js";"two.js"}
     names=seq {"bar";"baz";"n"}
     mappings="CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA"
     sourcesContent=None
     sourceRoot="/the/root"|>Some
    }
```
is serialized into
```json
{
  "version": 3,
  "sources": [
    "one.js",
    "two.js"
  ],
  "names": [
    "bar",
    "baz",
    "n"
  ],
  "mappings": "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
  "file": {
    "Value": "min.js"
  },
  "sourcesContent": null,
  "sourceRoot": {
    "Value": "/the/root"
  }
}
```

(Note how the option types are serialized)

This PR adds converters taking care of F# types, so that the previous example is changed into the following:
```json
{
  "version": 3,
  "sources": [
    "one.js",
    "two.js"
  ],
  "names": [
    "bar",
    "baz",
    "n"
  ],
  "mappings": "CAAC,IAAI,IAAM,SAAUA,GAClB,OAAOC,IAAID;CCDb,IAAI,IAAM,SAAUE,GAClB,OAAOA",
  "file": "min.js",
  "sourcesContent": null,
  "sourceRoot": "/the/root"
}
```

I wanted to use the `sourceRoot` property in Fable, but this serialization problem is preventing me from doing so.
This PR is a first step to fix the problem. I intend to open another one on the Fable project to fix serialization there too (hence the addition of a `SerializeAsync` method in this PR)

Note: I didn't write the F# converters myself. The original source is mentioned in the header of `FSharpConverters.fs`. I was not able to find a license, but since the scope of this code is limited, I assumed it would not be a blocker to use it...
