### PR TITLE
Switch result from a string to a StringBuilder

### DIFF
--- a/src/SourceMapGenerator.fs
+++ b/src/SourceMapGenerator.fs
@@ -135,7 +135,7 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
         let mutable previousOriginalLine = 0
         let mutable previousName = 0;
         let mutable previousSource = 0
-        let mutable result = ""
+        let result = System.Text.StringBuilder()
         let mutable next = ""
         let mutable nameIdx = 0
         let mutable sourceIdx  = 0
@@ -186,5 +186,5 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
                             next <- next + Base64Vlq.Encode (nameIdx - previousName)
                             previousName <- nameIdx
                         )
-                result <- result + next
-        result
+                result.Append(next) |> ignore
+        result.ToString()

--- a/src/SourceMapGenerator.fs
+++ b/src/SourceMapGenerator.fs
@@ -136,7 +136,7 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
         let mutable previousName = 0;
         let mutable previousSource = 0
         let result = System.Text.StringBuilder()
-        let mutable next = ""
+        let mutable next = System.Text.StringBuilder()
         let mutable nameIdx = 0
         let mutable sourceIdx  = 0
         let mappings = _mappings.ToArray()
@@ -144,11 +144,11 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
             // hack for 'continue' keyword in JS
             let mutable shouldContinue = false
             let mapping = mappings.[i]
-            next <- ""
+            next <- System.Text.StringBuilder()
             if mapping.Generated.line <> previousGeneratedLine then
                 previousGeneratedColumn <- 0
                 while mapping.Generated.line <> previousGeneratedLine do
-                    next <- next + ";"
+                    next.Append(";") |> ignore
                     previousGeneratedLine <- previousGeneratedLine + 1
             elif i > 0 then
                 let compared = compareByGeneratedPositionsInflated mapping mappings.[i-1]
@@ -156,35 +156,35 @@ type SourceMapGenerator(?skipValidation:bool, ?file:string, ?sourceRoot:string) 
                     // JS has 'continue' here, which we're emulating with a mutable bool
                     shouldContinue <- true
                 else
-                    next <- next + ","
+                    next.Append(",") |> ignore
             if not shouldContinue then
-                next <- next + Base64Vlq.Encode (mapping.Generated.column - previousGeneratedColumn)
+                next.Append(Base64Vlq.Encode (mapping.Generated.column - previousGeneratedColumn)) |> ignore
                 previousGeneratedColumn <- mapping.Generated.column
                 if mapping.Source.IsSome then
                     mapping.Source
-                    |> Option.bind (fun x -> this._sources.indexOf x)
+                    |> Option.bind (this._sources.indexOf)
                     |> Option.iter (fun indexOfMappingSource ->
                         sourceIdx <- indexOfMappingSource
-                        next <- next + Base64Vlq.Encode (sourceIdx - previousSource)
+                        next.Append(Base64Vlq.Encode (sourceIdx - previousSource)) |> ignore
                         previousSource <- sourceIdx
                     )
                     // lines are stored 0-based in SourceMap spec version 3
                     mapping.Original
                     |> Option.iter (fun original ->
-                        next <- next + Base64Vlq.Encode (original.line - 1 - previousOriginalLine)
+                        next.Append(Base64Vlq.Encode (original.line - 1 - previousOriginalLine)) |> ignore
                         previousOriginalLine <- original.line - 1
 
-                        next <- next + Base64Vlq.Encode (original.column - previousOriginalColumn)
+                        next.Append(Base64Vlq.Encode (original.column - previousOriginalColumn)) |> ignore
                         previousOriginalColumn <- original.column
                     )
 
                     if mapping.Name.IsSome then
                         mapping.Name
-                        |> Option.bind (fun x -> _names.indexOf x)
+                        |> Option.bind (_names.indexOf)
                         |> Option.iter (fun indexOfMappingName ->
                             nameIdx <- indexOfMappingName
-                            next <- next + Base64Vlq.Encode (nameIdx - previousName)
+                            next.Append(Base64Vlq.Encode (nameIdx - previousName)) |> ignore
                             previousName <- nameIdx
                         )
-                result.Append(next) |> ignore
+                result.Append(next.ToString()) |> ignore
         result.ToString()


### PR DESCRIPTION
I’ve got a 323KB JS file and for some reason the source map takes a very, very long time to complete which means the whole fable convert has become unsuitably slow with the --sourceMaps option.

This isn’t the biggest file in my project just something about the structure must make the source map generation run slowly.

I just tried a quick test swapping out the string for a string builder and it’s now running a lot faster.

![image](https://user-images.githubusercontent.com/1804141/151986309-9f94c17e-a04b-4a82-85f8-0685c7e98007.png)
